### PR TITLE
Small patch

### DIFF
--- a/speak/module.py
+++ b/speak/module.py
@@ -31,7 +31,7 @@ class Speak(commands.Cog):
     @check.acl2(check.ACLevel.MEMBER)
     @commands.command()
     async def speak(self, ctx: commands.Context):
-        """What should BolGPT say?"""
+        """What should GPT say?"""
         async with ctx.typing():
             text = ctx.message.content.lstrip(f"{ctx.prefix}").lstrip(
                 f"{str(ctx.command.name)} "

--- a/speak/module.py
+++ b/speak/module.py
@@ -30,13 +30,9 @@ class Speak(commands.Cog):
     @commands.cooldown(rate=1, per=2.0, type=commands.BucketType.user)
     @check.acl2(check.ACLevel.MEMBER)
     @commands.command()
-    async def speak(self, ctx: commands.Context):
+    async def speak(self, ctx: commands.Context, *, text: str):
         """What should GPT say?"""
         async with ctx.typing():
-            text = ctx.message.content.lstrip(f"{ctx.prefix}").lstrip(
-                f"{str(ctx.command.name)} "
-            )
-
             input_ids = self.tokenizer.encode(
                 "<|endoftext|>" + text, return_tensors="pt"
             ).to(self.device)


### PR DESCRIPTION
- Do not hardcode model name into `speak` command
- Simplify input parsing and prevent it from eating characters on the start of the string